### PR TITLE
Generate LLMs text during site build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -12,8 +12,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -25,9 +23,13 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
@@ -57,6 +59,9 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,68 @@
+# workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Run custom scripts
+        run: |
+          ruby bin/merge_md_files.rb
+          php bin/generate_llms_full.php
+
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 watch
+llms-full.txt

--- a/bin/generate_llms_full.php
+++ b/bin/generate_llms_full.php
@@ -21,6 +21,9 @@ function generateLlmsFull(): void
 
     echo "Reading llms.txt...\n";
     $content = file_get_contents($llmsFile);
+    if ($content === false) {
+        throw new RuntimeException("Failed to read llms.txt at: $llmsFile");
+    }
 
     // Extract the header section (before first ## section with links)
     $lines = explode("\n", $content);
@@ -100,7 +103,11 @@ function generateLlmsFull(): void
     }
 
     // Write the result
-    file_put_contents($outputFile, $fullContent);
+    $bytesWritten = file_put_contents($outputFile, $fullContent);
+    if ($bytesWritten === false || $bytesWritten !== strlen($fullContent)) {
+        throw new RuntimeException("Failed to write complete llms-full.txt to: $outputFile");
+    }
+
     echo "Generated llms-full.txt successfully!\n";
     echo "File size: " . number_format(strlen($fullContent)) . " characters\n";
 }
@@ -119,9 +126,15 @@ function parseMarkdownPath(string $url, string $baseDir): ?string
 function includeMarkdownFile(string $filePath): string
 {
     $content = file_get_contents($filePath);
+    if ($content === false) {
+        throw new RuntimeException("Failed to read markdown file: $filePath");
+    }
 
     // Remove Jekyll front matter (handles optional whitespace/comments before, and flexible closing '---')
     $content = preg_replace('/\A(?:\s*|<!--.*?-->\s*)*---\s*\n(.*?)\n---\s*(?:\n|$)/s', '', $content);
+    if ($content === null) {
+        throw new RuntimeException("Failed to strip front matter from markdown file: $filePath");
+    }
 
     // Clean up the content
     $content = trim($content);
@@ -163,6 +176,9 @@ function includeMarkdownFile(string $filePath): string
         },
         $content
     );
+    if ($content === null) {
+        throw new RuntimeException("Failed to convert markdown links in: $filePath");
+    }
 
     return $content;
 }

--- a/bin/generate_llms_full.php
+++ b/bin/generate_llms_full.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Generate llms-full.txt from llms.txt by expanding linked markdown files
+ *
+ * This script follows the llms.txt standard and creates a comprehensive
+ * documentation file for AI assistants by including the content of all
+ * linked markdown files.
+ */
+
+declare(strict_types=1);
+
+function generateLlmsFull(): void
+{
+    $baseDir = dirname(__DIR__);
+    $llmsFile = $baseDir . '/llms.txt';
+    $outputFile = $baseDir . '/llms-full.txt';
+
+    if (!file_exists($llmsFile)) {
+        throw new RuntimeException("llms.txt not found at: $llmsFile");
+    }
+
+    echo "Reading llms.txt...\n";
+    $content = file_get_contents($llmsFile);
+
+    // Extract the header section (before first ## section with links)
+    $lines = explode("\n", $content);
+    $headerLines = [];
+    $linkSections = [];
+    $currentSection = null;
+    $inLinkSection = false;
+
+    foreach ($lines as $line) {
+        // Check if this is a section header
+        if (preg_match('/^## (.+)$/', $line, $matches)) {
+            $sectionName = $matches[1];
+            $currentSection = $sectionName;
+            $inLinkSection = false;
+            $headerLines[] = $line;
+        } elseif (preg_match('/^- \[([^\]]+)\]\(([^)]+)\)/', $line, $matches)) {
+            // Found a markdown link - start processing this section for link expansion
+            if (!$inLinkSection) {
+                $inLinkSection = true;
+                // Remove the section header from headerLines since we'll process it
+                array_pop($headerLines);
+                if (!isset($linkSections[$currentSection])) {
+                    $linkSections[$currentSection] = [];
+                }
+            }
+            // Extract link information
+            $title = $matches[1];
+            $url = $matches[2];
+            $linkSections[$currentSection][] = [
+                'title' => $title,
+                'url' => $url,
+                'line' => $line
+            ];
+        } elseif (!$inLinkSection) {
+            $headerLines[] = $line;
+        }
+    }
+
+    // Start building the full content
+    $fullContent = implode("\n", $headerLines) . "\n";
+
+    // Add the link sections for reference with internal anchors
+    foreach ($linkSections as $sectionName => $links) {
+        $fullContent .= "\n## $sectionName\n\n";
+        foreach ($links as $link) {
+            // Convert file path links to internal anchors
+            $anchorName = basename($link['url'], '.md');
+            $anchorName = strtolower(str_replace(['_', ' '], '-', $anchorName));
+            // Extract just the description part after the colon, removing the markdown link
+            $description = '';
+            if (preg_match('/:\s*(.+)$/', $link['line'], $matches)) {
+                $description = trim($matches[1]);
+            }
+            $internalLink = "- [{$link['title']}](#{$anchorName}): {$description}";
+            $fullContent .= $internalLink . "\n";
+        }
+    }
+
+    $fullContent .= "\n---\n";
+
+    // Process each link and include the content
+    foreach ($linkSections as $sectionName => $links) {
+        foreach ($links as $link) {
+            $markdownPath = parseMarkdownPath($link['url'], $baseDir);
+            if ($markdownPath && file_exists($markdownPath) && is_readable($markdownPath)) {
+                echo "Including: {$link['title']} from $markdownPath\n";
+                $markdownContent = includeMarkdownFile($markdownPath);
+                if ($markdownContent === false || $markdownContent === null || trim($markdownContent) === '') {
+                    echo "Error: Failed to read or invalid markdown content in {$link['title']} ($markdownPath)\n";
+                    continue;
+                }
+                $fullContent .= "\n" . $markdownContent . "\n";
+            } else {
+                echo "Warning: Could not find file for {$link['title']} at $markdownPath\n";
+            }
+        }
+    }
+
+    // Write the result
+    file_put_contents($outputFile, $fullContent);
+    echo "Generated llms-full.txt successfully!\n";
+    echo "File size: " . number_format(strlen($fullContent)) . " characters\n";
+}
+
+function parseMarkdownPath(string $url, string $baseDir): ?string
+{
+    // Convert URL to local file path
+    if (strpos($url, '/manuals/1.0/en/') === 0) {
+        $relativePath = ltrim($url, '/');
+        return $baseDir . '/' . $relativePath;
+    }
+
+    return null;
+}
+
+function includeMarkdownFile(string $filePath): string
+{
+    $content = file_get_contents($filePath);
+
+    // Remove Jekyll front matter (handles optional whitespace/comments before, and flexible closing '---')
+    $content = preg_replace('/\A(?:\s*|<!--.*?-->\s*)*---\s*\n(.*?)\n---\s*(?:\n|$)/s', '', $content);
+
+    // Clean up the content
+    $content = trim($content);
+
+    // Convert relative links to section references, handling anchors and query parameters
+    $content = preg_replace_callback(
+        '/\[([^\]]+)\]\(([^)]+)\)/',
+        function ($matches) {
+            $text = $matches[1];
+            $url = $matches[2];
+
+            // Skip external links
+            if (preg_match('#^(?:[a-z][a-z0-9+\-.]*:)?//#i', $url)) {
+                return $matches[0];
+            }
+
+            // Only process .md links (with or without anchors/query)
+            if (preg_match('/\.md(\?|#|$)/i', $url)) {
+                // Split off anchor and query if present
+                $urlParts = parse_url($url);
+                $file = $urlParts['path'] ?? $url;
+                $anchor = $urlParts['fragment'] ?? '';
+
+                // Generate section name from file name
+                $sectionName = basename($file, '.md');
+                $sectionName = str_replace(['-', '_'], ' ', $sectionName);
+                $sectionName = ucwords($sectionName);
+                $sectionAnchor = strtolower(str_replace(' ', '-', $sectionName));
+
+                // If original link had an anchor, append it
+                if ($anchor !== '') {
+                    $sectionAnchor .= '-' . strtolower(str_replace([' ', '_'], '-', $anchor));
+                }
+
+                return "[$text](#" . $sectionAnchor . ")";
+            }
+
+            return $matches[0];
+        },
+        $content
+    );
+
+    return $content;
+}
+
+// Main execution
+try {
+    generateLlmsFull();
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/bin/serve_local.sh
+++ b/bin/serve_local.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -euo pipefail
+trap 'echo "serve_local.sh failed; check generate_llms_full.php or Jekyll output above." >&2' ERR
+
 # This script is used to serve the Jekyll site locally with automatic rebuilding.
 # 'bundle exec' ensures we're using the correct versions of each gem according to our Gemfile.lock.
 # 'jekyll serve' starts a Jekyll development server.

--- a/bin/serve_local.sh
+++ b/bin/serve_local.sh
@@ -3,4 +3,6 @@
 # 'bundle exec' ensures we're using the correct versions of each gem according to our Gemfile.lock.
 # 'jekyll serve' starts a Jekyll development server.
 # '--watch' option automatically rebuilds the site when files are modified.
+
+php bin/generate_llms_full.php
 bundle exec jekyll serve --watch --trace

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,5 @@
+# llms.txt
+
+## Overview
+
+- [Quick Start](/manuals/1.0/en/quick-start.md): Quick setup with Composer


### PR DESCRIPTION
## Summary
- add llms.txt and an llms-full.txt generator to the skeleton
- generate llms-full.txt during the Pages build and local serve setup
- ignore generated llms-full.txt

## Verification
- zsh -ic "sphp85; php -l bin/generate_llms_full.php"
- zsh -ic "sphp85; php bin/generate_llms_full.php"
- git diff --cached --check

Note: local Jekyll build was not run successfully because required bundle gems are not installed in this local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new LLM reference with a Quick Start link and a consolidated full reference for easier browsing.

* **Chores**
  * Enabled automatic site build & GitHub Pages deployment.
  * Updated local dev server to generate documentation before serving.
  * Ignored generated reference file in version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koriym/user-manual-skeleton/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->